### PR TITLE
feat: select new font (Inter)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>auto-poc</title>
     <!-- SPA redirect handler: decode path from 404.html query param redirect -->

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,5 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
 


### PR DESCRIPTION
Switches the site font from the default system-ui stack to Inter, a modern variable font designed for screens and used by Vercel, Linear, and many modern web apps.

Changes:
- Added Google Fonts preconnect and Inter import in index.html
- Updated font-family in src/index.css

Closes #9

Generated with [Claude Code](https://claude.ai/code)